### PR TITLE
css: Solapamiento de patrocinadores con mapa

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -508,8 +508,9 @@ nav a:focus { color: #fff; }
 /** Patrocinadores **/
 .patrocinadores-container {
 	text-align: center;
-    height: 500px;
-    margin-bottom: 400px;
+    height: auto;
+    margin: 60px auto 0 auto;
+    padding-bottom: 60px;
     /*padding-bottom: 80px;*/
 	/*background-color:*/ 
 }
@@ -530,8 +531,10 @@ nav a:focus { color: #fff; }
 /** Organizadores **/
 	
 .organizadores-container {
+    margin: 60px auto 0 auto;
+    padding-bottom: 60px;
 	text-align: center;
-    height: 500px;
+    height: auto;
 }
 
 .registro-container{
@@ -541,10 +544,12 @@ nav a:focus { color: #fff; }
 }
 
 .mapa-container {
+    margin: 60px auto 0 auto;
+    padding-bottom: 100px;
     margin-top: 0px;
     color: #fff;
     text-align: center;
-    height: 600px;
+    min-height: 400px;
 }
 
 .mapa-container iframe {


### PR DESCRIPTION
A partir de una altura de página menor a 760 px (visible sobretodo a través
de smartphone) se produce un fallo con el diseño responsive de la página. Se
solapa el bloque-patrocinadores con los siguientes bloques de la página.

Eliminado el solapamiento comentado, se corrige el solapamiento entre
bloque-mapa y bloque-organizadores.
